### PR TITLE
Sync first roll

### DIFF
--- a/src/components/ThreeDice/GameManager.js
+++ b/src/components/ThreeDice/GameManager.js
@@ -39,7 +39,7 @@ const GameManager = (props) => {
     if (gameStarted) {
       rollSound();
     }
-  }, [reroll, socket, gameStarted]);
+  }, [reroll, gameStarted]);
 
   return (
     <>
@@ -76,6 +76,7 @@ const GameManager = (props) => {
             socket={socket}
             roomId={roomId}
             gameStatus={gameStatus}
+            rollSound={rollSound}
           />
           <Html position={[-3, 0, 7]} scaleFactor={25}>
             <Button
@@ -99,6 +100,7 @@ const GameManager = (props) => {
             socket={socket}
             gameStatus={gameStatus}
             roomId={roomId}
+            rollSound={rollSound}
           />
         </>
       )}

--- a/src/components/ThreeDice/GameManager.js
+++ b/src/components/ThreeDice/GameManager.js
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from "react";
+import React, { Suspense, useState, useEffect } from "react";
 import { Html, useGLTF, useProgress } from "@react-three/drei";
 import Button from "@material-ui/core/Button";
 import { makeStyles } from "@material-ui/core/styles";
@@ -11,6 +11,10 @@ import UserDiceManager from "./UserDiceManager";
 
 const getRole = () =>
   sessionStorage.getItem("role") ? sessionStorage.getItem("role") : "user";
+
+const rollSound = () => {
+  new Audio("/diceRoll.m4a").play();
+};
 
 /* istanbul ignore next */
 const GameManager = (props) => {
@@ -30,6 +34,12 @@ const GameManager = (props) => {
   }));
 
   const classes = useStyles();
+
+  useEffect(() => {
+    if (gameStarted) {
+      rollSound();
+    }
+  }, [reroll, socket, gameStarted]);
 
   return (
     <>

--- a/src/components/ThreeDice/GameManager.js
+++ b/src/components/ThreeDice/GameManager.js
@@ -17,7 +17,6 @@ const GameManager = (props) => {
   const { setOrbitControl, socket, roomId, gameStatus } = props;
   const [gameStarted, setGameState] = useState(gameStatus);
   const [reroll, rerollDice] = useAtom(rerollState);
-  const rollSound = new Audio("/diceRoll.m4a");
   const role = getRole();
   const useStyles = makeStyles((theme) => ({
     button: {
@@ -53,7 +52,6 @@ const GameManager = (props) => {
             endIcon={<Icon>casino</Icon>}
             onClick={() => {
               setGameState(true);
-              rollSound.play();
             }}
           >
             Start Game
@@ -77,7 +75,6 @@ const GameManager = (props) => {
               endIcon={<Icon>casino</Icon>}
               onClick={() => {
                 rerollDice(!reroll);
-                rollSound.play();
               }}
             >
               Roll It!

--- a/src/components/ThreeDice/HostDiceManager.js
+++ b/src/components/ThreeDice/HostDiceManager.js
@@ -212,10 +212,6 @@ const DiceManager = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rerollFive]);
 
-  useEffect(() => {
-    rollSound();
-  }, [reroll]);
-
   const { viewport } = useThree();
   const mousePos = [];
 

--- a/src/components/ThreeDice/HostDiceManager.js
+++ b/src/components/ThreeDice/HostDiceManager.js
@@ -10,13 +10,17 @@ import CollisionMesh from "./CollisionMesh";
 import { diceDefaultState } from "./gameState";
 
 const newRotationArray = () => [Math.random(), Math.random(), Math.random()];
-const rollSound = () => {
-  new Audio("/diceRoll.m4a").play();
-};
 
 /* istanbul ignore next */
 const DiceManager = (props) => {
-  const { reroll, setOrbitControl, socket, roomId, gameStatus } = props;
+  const {
+    reroll,
+    setOrbitControl,
+    socket,
+    roomId,
+    gameStatus,
+    rollSound,
+  } = props;
   const geom = useMemo(() => new BoxBufferGeometry(), []);
 
   const [dicePosition] = useAtom(diceDefaultState);
@@ -247,6 +251,7 @@ DiceManager.propTypes = {
   setOrbitControl: PropTypes.func.isRequired,
   roomId: PropTypes.string.isRequired,
   gameStatus: PropTypes.bool.isRequired,
+  rollSound: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   socket: PropTypes.object.isRequired,
 };

--- a/src/components/ThreeDice/HostDiceManager.js
+++ b/src/components/ThreeDice/HostDiceManager.js
@@ -10,6 +10,9 @@ import CollisionMesh from "./CollisionMesh";
 import { diceDefaultState } from "./gameState";
 
 const newRotationArray = () => [Math.random(), Math.random(), Math.random()];
+const rollSound = () => {
+  new Audio("/diceRoll.m4a").play();
+};
 
 /* istanbul ignore next */
 const DiceManager = (props) => {
@@ -148,6 +151,7 @@ const DiceManager = (props) => {
         // eslint-disable-next-line array-callback-return
         imageArray[rollObject.die].setImages(rollObject.image);
         rotationArray[rollObject.die].setRotation(rollObject.rotation);
+        rollSound();
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -207,6 +211,10 @@ const DiceManager = (props) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rerollFive]);
+
+  useEffect(() => {
+    rollSound();
+  }, [reroll]);
 
   const { viewport } = useThree();
   const mousePos = [];

--- a/src/components/ThreeDice/UserDiceManager.js
+++ b/src/components/ThreeDice/UserDiceManager.js
@@ -73,6 +73,7 @@ const UserDiceManager = (props) => {
         rotationArray[index].setRotation(rotationValues[index]);
       });
       setWaitingForInit(false);
+      rollSound();
     });
     socket.on("user:initQueue", (rollObject) => {
       if (rollObject.die === null) {
@@ -82,6 +83,7 @@ const UserDiceManager = (props) => {
           rotationArray[index].setRotation(rollObject.rotation[index]);
         });
         setWaitingForInit(false);
+        rollSound();
       } else {
         // eslint-disable-next-line array-callback-return
         imageArray[rollObject.die].setImages(rollObject.image);

--- a/src/components/ThreeDice/UserDiceManager.js
+++ b/src/components/ThreeDice/UserDiceManager.js
@@ -14,7 +14,6 @@ import { diceDefaultState } from "./gameState";
 const rollSound = () => {
   new Audio("/diceRoll.m4a").play();
 };
-setTimeout(rollSound, 1000);
 
 /* istanbul ignore next */
 const UserDiceManager = (props) => {
@@ -102,13 +101,11 @@ const UserDiceManager = (props) => {
       });
       if (!userGameReady) setUserReady(true);
       if (waitingForInit) setWaitingForInit(false);
-      rollSound();
     });
     socket.on("user:getDieRoll", (rotationValue, newImage, index) => {
       imageArray[index].setImages(newImage);
       rotationArray[index].setRotation(rotationValue);
       setWaitingForInit(false);
-      rollSound();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/ThreeDice/UserDiceManager.js
+++ b/src/components/ThreeDice/UserDiceManager.js
@@ -11,13 +11,9 @@ import UserThemedDie from "./UserThemedDie";
 import CollisionMesh from "./CollisionMesh";
 import { diceDefaultState } from "./gameState";
 
-const rollSound = () => {
-  new Audio("/diceRoll.m4a").play();
-};
-
 /* istanbul ignore next */
 const UserDiceManager = (props) => {
-  const { setOrbitControl, socket, roomId, gameStatus } = props;
+  const { setOrbitControl, socket, roomId, gameStatus, rollSound } = props;
   const geom = useMemo(() => new BoxBufferGeometry(), []);
 
   const [userGameReady, setUserReady] = useState(gameStatus);
@@ -101,11 +97,13 @@ const UserDiceManager = (props) => {
       });
       if (!userGameReady) setUserReady(true);
       if (waitingForInit) setWaitingForInit(false);
+      rollSound();
     });
     socket.on("user:getDieRoll", (rotationValue, newImage, index) => {
       imageArray[index].setImages(newImage);
       rotationArray[index].setRotation(rotationValue);
       setWaitingForInit(false);
+      rollSound();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -158,6 +156,7 @@ UserDiceManager.propTypes = {
   setOrbitControl: PropTypes.func.isRequired,
   gameStatus: PropTypes.bool.isRequired,
   roomId: PropTypes.string.isRequired,
+  rollSound: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   socket: PropTypes.object.isRequired,
 };

--- a/src/components/ThreeDice/UserDiceManager.js
+++ b/src/components/ThreeDice/UserDiceManager.js
@@ -11,6 +11,11 @@ import UserThemedDie from "./UserThemedDie";
 import CollisionMesh from "./CollisionMesh";
 import { diceDefaultState } from "./gameState";
 
+const rollSound = () => {
+  new Audio("/diceRoll.m4a").play();
+};
+setTimeout(rollSound, 1000);
+
 /* istanbul ignore next */
 const UserDiceManager = (props) => {
   const { setOrbitControl, socket, roomId, gameStatus } = props;
@@ -86,6 +91,7 @@ const UserDiceManager = (props) => {
         // eslint-disable-next-line array-callback-return
         imageArray[rollObject.die].setImages(rollObject.image);
         rotationArray[rollObject.die].setRotation(rollObject.rotation);
+        rollSound();
       }
     });
     socket.on("user:getRoll", (rotationValues, imagesArray) => {
@@ -96,11 +102,13 @@ const UserDiceManager = (props) => {
       });
       if (!userGameReady) setUserReady(true);
       if (waitingForInit) setWaitingForInit(false);
+      rollSound();
     });
     socket.on("user:getDieRoll", (rotationValue, newImage, index) => {
       imageArray[index].setImages(newImage);
       rotationArray[index].setRotation(rotationValue);
       setWaitingForInit(false);
+      rollSound();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
==== Coverage summary =====
Statements   : 91.09% ( 184/202 )
Branches     : 78.95% ( 30/38 )
Functions    : 89.09% ( 49/55 )
Lines        : 91.53% ( 173/189 )

Ties the audio playing to either the socket.on functions for `UserDiceManager` or in a useEffect hook in `GameManager.js` for the host.

For the host, it should eliminate the sound playing offsync because it will only play after the re-render is done. So, it should be until after the dice are ready to roll. 

Adding `Socket` to the useEffect dependencies in `GameManager.js` didn't play the audio for a user, so the audio playing needed to be in the `socket.on` functions.